### PR TITLE
Changed Life Stock from Filler to Progression

### DIFF
--- a/worlds/Landstalker - The Treasures of King Nole/progression.txt
+++ b/worlds/Landstalker - The Treasures of King Nole/progression.txt
@@ -51,7 +51,7 @@ Short Cake: useful
 Gola's Nail: progression
 Gola's Horn: progression
 Gola's Fang: progression
-Life Stock: filler
+Life Stock: progression
 No Item: filler
 1 Gold: filler
 20 Golds: filler


### PR DESCRIPTION
I changed the classification due to a check requiring you to have 15 Life Stocks. 

Im pretty sure most of them are filler however but they do lock a check (which could also be late sphere too depending on luck)